### PR TITLE
Fix a bug with mods that add radar upgrades

### DIFF
--- a/prototypes/zipline.lua
+++ b/prototypes/zipline.lua
@@ -1,5 +1,7 @@
 local brrr = table.deepcopy(data.raw.radar["radar"])
 brrr.name = "RTZipline"
+brrr.next_upgrade = nil
+brrr.not_upgradable = true
 brrr.selectable_in_game = false
 brrr.flags = {"placeable-off-grid", "not-on-map", "not-blueprintable", "not-deconstructable", "not-flammable", "no-copy-paste"}
 brrr.collision_mask = {}


### PR DESCRIPTION
I had an issue with 5Dim's mods due `radar` having an upgrade to `5d-radar-02`, this resulted in issues with the collision masks not matching, and caused the game to not boot. All this does is remove the upgrade thus ensuring that no errors occur.